### PR TITLE
Fix quote when switching between storepickup and shipping tabs

### DIFF
--- a/app/code/Magento/InventoryInStorePickupFrontend/view/frontend/web/js/view/store-pickup.js
+++ b/app/code/Magento/InventoryInStorePickupFrontend/view/frontend/web/js/view/store-pickup.js
@@ -15,6 +15,7 @@ define([
     'Magento_Checkout/js/model/shipping-service',
     'Magento_Checkout/js/model/step-navigator',
     'Magento_Checkout/js/model/shipping-rate-service',
+    'Magento_Checkout/js/model/address-converter',
     'Magento_InventoryInStorePickupFrontend/js/model/shipping-rate-processor/store-pickup-address',
     'Magento_InventoryInStorePickupFrontend/js/model/pickup-locations-service',
 ], function(
@@ -29,6 +30,7 @@ define([
     shippingService,
     stepNavigator,
     shippingRateService,
+    addressConverter,
     shippingRateProcessor,
     pickupLocationsService
 ) {
@@ -115,13 +117,15 @@ define([
 
             this.selectShippingMethod(nonPickupShippingMethod);
 
-            registry.async('checkoutProvider')(function(checkoutProvider) {
-                checkoutProvider.set(
-                    'shippingAddress',
-                    quote.shippingAddress()
-                );
-                checkoutProvider.trigger('data.reset');
-            });
+            if(checkoutData.getSelectedShippingAddress() === 'store-pickup-address') {
+                registry.async('checkoutProvider')(function(checkoutProvider) {
+                    checkoutProvider.set(
+                        'shippingAddress',
+                        addressConverter.formAddressDataToQuoteAddress({})
+                    );
+                    checkoutProvider.trigger('data.reset');
+                });
+            }
         },
         selectStorePickup: function() {
             var pickupShippingMethod = _.find(
@@ -143,15 +147,13 @@ define([
          */
         selectShippingMethod: function(shippingMethod) {
             selectShippingMethodAction(shippingMethod);
-            checkoutData.setSelectedShippingAddress(
-                quote.shippingAddress().getKey()
-            );
         },
         convertAddressType: function(shippingAddress) {
             if (
                 !this.isStorePickupAddress(shippingAddress) &&
                 this.isStorePickupSelected()
             ) {
+
                 quote.shippingAddress(
                     $.extend({}, shippingAddress, {
                         canUseForBilling: function() {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Do not allow store pickup address to stay in quote when switching between store pickup and shipping tab


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/inventory#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Steps to reproduce:

As a Logged-in User, go to Checkout Step-2

Select Pick-in-Store

Select any Store

Go to Checkout Step-3

Go back to Checkout Step-2

Select Home Delivery

Do NOT select any (home) Shipping Address

Go to Checkout Step-3

Expected result:
The Next Step button is inactive in the Checkout Step-2 without providing the Shipping Address (I am unable to reach the Checkout Step-3)

Actual result:
I am able to go to the Checkout Step-3 without selecting a Shipping Address from My Addresses box → Shipping Address is provided from Pick-in-Store option into Checkout Step-3

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
